### PR TITLE
FIXED rake api paths

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -23,7 +23,7 @@ end
 
 desc "Rebuild API reference"
 task :api do
-  sh "yard doc -o doc/api/ opal/**/*.rb"
+  sh "yard doc -o doc/api/ lib/**/*.rb lib/**/**/*.rb"
 end
 
 desc "git ci, git tag and git push"


### PR DESCRIPTION
Hello. I would like to refer to the [API reference](https://yhara.github.io/dxopal/doc/api/index.html), but the class list seems to be empty.
I changed the rake api command path to show the class list.
