### PR TITLE
Add `-b :bind-address:` option for `dxopal server` command.

### DIFF
--- a/exe/dxopal
+++ b/exe/dxopal
@@ -44,12 +44,13 @@ module DXOpal
 
     desc "server", "Start local server"
     option "port", aliases: :p, type: :numeric, default: 7521
+    option "bind_address", aliases: :b, type: :string, default: 'localhost'
     def server
       puts "Starting DXOpal Server"
-      puts "(Open http://localhost:#{options[:port]}/index.html in the browser)"
+      puts "(Open http://#{options[:bind_address]}:#{options[:port]}/index.html in the browser)"
       puts "---"
       app = Rack::CommonLogger.new(Rack::Directory.new(Dir.pwd))
-      Rack::Server.start(app: app, Port: options[:port])
+      Rack::Server.start(app: app, BindAddress: options[:bind_address], Port: options[:port])
     end
   end
 end


### PR DESCRIPTION
Add `-b :bind-address:` option for `dxopal server`.

For example, It is used like `dxopal server -b 0.0.0.0` 