### PR TITLE
fix: Incorrect behavior in Input.mouse_push? and Input.touch_push?

### DIFF
--- a/lib/dxopal/input.rb
+++ b/lib/dxopal/input.rb
@@ -171,7 +171,7 @@ module DXOpal
     # Return true if the mouse button is pressed in the last tick
     def self.mouse_push?(mouse_code)
       raise "missing argument of `mouse_push?'" unless mouse_code
-      return `#{@@pressing_mouse_buttons}[mouse_code] == -(#{@@tick}-1)`
+      return `#{@@pressing_mouse_buttons}[mouse_code] == #{@@tick}-1`
     end
 
     # Return true if the mouse button is released in the last tick
@@ -261,7 +261,7 @@ module DXOpal
 
     # Return true if the touch is pressed in the last tick
     def self.touch_push?
-      return `#{@@pressing_touch}[0] == -(#{@@tick}-1)`
+      return `#{@@pressing_touch}[0] == #{@@tick}-1`
     end
 
     # Return true if the touch is released in the last tick


### PR DESCRIPTION
The implementations of `mouse_push?` and `mouse_release?` are identical, which appears to be a simple editing error.

The same applies to `touch_push?`.

---

Verification code:

```rb
require "dxopal"

FONT = Font.new(12, "monospace")

def draw_lane(x, y, name)
  Window.draw_font(x, 0, name, FONT)
  Window.draw_circle_fill(x, y, 10, C_RED)
end

map_y = {
  m_down: 0, m_push: 0, m_release: 0,
  t_down: 0, t_push: 0, t_release: 0,
}

Window.load_resources do
  Window.loop do
    map_y[:m_down   ] = 0 if Input.mouse_down?(M_LBUTTON)
    map_y[:m_push   ] = 0 if Input.mouse_push?(M_LBUTTON)
    map_y[:m_release] = 0 if Input.mouse_release?(M_LBUTTON)

    map_y[:t_down   ] = 0 if Input.touch_down?
    map_y[:t_push   ] = 0 if Input.touch_push?
    map_y[:t_release] = 0 if Input.touch_release?

    [
      :m_down, :m_push, :m_release,
      :t_down, :t_push, :t_release,
    ].each_with_index do |key, i|
      x = 20 + i * 80
      draw_lane(x, map_y[key], key)
    end

    map_y.each_key do |key|
      y = map_y[key] + 1
      map_y[key] = [Window.height - 20, y].min
    end
  end
end
```
